### PR TITLE
patch: fix version display format to show 'Current (v4.2.6)'

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -91,7 +91,7 @@ const config = {
           // Previous version (N-1) is automatically managed via versions.json
           versions: {
             current: {
-              label: `${currentVersion} (Current)`,
+              label: `Current (${currentVersion})`,
               badge: true,
               path: '/docs',
             },


### PR DESCRIPTION
## Summary

Fixes the version display format in the documentation site to show the proper format: **"Current (v4.2.6)"** instead of "v4.2.6 (Current)".

## Issue

The sidebar was showing the version in the wrong format:
- **Before**: `v4.2.6 (Current)` 
- **After**: `Current (v4.2.6)`

This matches the expected format where the version number follows the "Current" label, making it consistent with standard Docusaurus version dropdown patterns.

## Changes

- Updated `website/docusaurus.config.js` to change version label format
- Modified the `current.label` from `` `${currentVersion} (Current)` `` to `` `Current (${currentVersion})` ``
- Maintains dynamic version loading from `version.json`

## Result

The version dropdown and sidebar will now display:
- **Version Dropdown**: "Current (v4.2.6)"
- **Sidebar**: Proper "current" link with correct format

## Test Plan

- [x] Docusaurus build succeeds with updated format
- [x] Version displays correctly in expected format
- [ ] Verify version dropdown shows "Current (v4.2.6)" in UI

This is a minor patch that fixes the display format without affecting functionality.

🤖 Generated with [Claude Code](https://claude.ai/code)